### PR TITLE
feat: use pytorch built-in interpolation method for `LinearInterpolation`

### DIFF
--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -14,7 +14,6 @@
 # limitations under the License.                                           #
 # ------------------------------------------------------------------------ #
 
-import numpy as np
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -40,7 +40,6 @@ class LinearInterpolation(nn.Module):
         assert 1 <= self.upsampling_factor
 
         self.pad = nn.ReplicationPad1d((0, 1))
-        self.scale_factor = upsampling_factor
 
     def forward(self, x):
         """Interpolate filter coefficients.

--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -85,7 +85,9 @@ class LinearInterpolation(nn.Module):
             (x.size(-1) - 1) * self.scale_factor + 1,
             mode="linear",
             align_corners=True,
-        )[..., :-1]
+        )[
+            ..., :-1
+        ]  # remove the padded value
         y = x.transpose(1, 2).reshape(B, -1, D)
 
         if d == 1:

--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -81,7 +81,7 @@ class LinearInterpolation(nn.Module):
         x = self.pad(x)
         x = F.interpolate(
             x,
-            (x.size(-1) - 1) * self.scale_factor + 1,
+            size=T * self.upsampling_factor + 1,
             mode="linear",
             align_corners=True,
         )[

--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -18,8 +18,6 @@ import numpy as np
 import torch.nn as nn
 import torch.nn.functional as F
 
-from ..misc.utils import numpy_to_torch
-
 
 class LinearInterpolation(nn.Module):
     """Perform linear interpolation.

--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -75,7 +75,7 @@ class LinearInterpolation(nn.Module):
         elif d == 2:
             x = x.unsqueeze(0)
         assert x.dim() == 3, "Input must be 3D tensor"
-        B, _, D = x.shape
+        B, T, D = x.shape
 
         x = x.transpose(1, 2)
         x = self.pad(x)

--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -66,7 +66,7 @@ class LinearInterpolation(nn.Module):
 
         """
         # Return copy if upsampling factor is one.
-        if self.scale_factor == 1:
+        if self.upsampling_factor == 1:
             return x
 
         d = x.dim()

--- a/diffsptk/core/linear_intpl.py
+++ b/diffsptk/core/linear_intpl.py
@@ -35,7 +35,9 @@ class LinearInterpolation(nn.Module):
     def __init__(self, upsampling_factor):
         super(LinearInterpolation, self).__init__()
 
-        assert 1 <= upsampling_factor
+        self.upsampling_factor = upsampling_factor
+
+        assert 1 <= self.upsampling_factor
 
         self.pad = nn.ReplicationPad1d((0, 1))
         self.scale_factor = upsampling_factor


### PR DESCRIPTION
I was using the mlsa filter module and found some places that can be optimised.
I replaced the convolution-based linear interpolation with pytorch built-in method and did some benchmarks.

### Before
```

[--------------- linear_interpolation ---------------]
              |  scale_factor=128  |  scale_factor=256
1 threads: -------------------------------------------
      N=512   |        419.0       |        853.9     
      N=1024  |        849.4       |       1716.3     
      N=2048  |       1884.4       |       4325.4     
2 threads: -------------------------------------------
      N=512   |        281.6       |        562.4     
      N=1024  |        556.1       |       1153.5     
      N=2048  |       1188.4       |       2449.0     
4 threads: -------------------------------------------
      N=512   |        221.7       |        422.7     
      N=1024  |        419.9       |        864.5     
      N=2048  |        882.8       |       1788.6     

Times are in milliseconds (ms).
```

### After

```
[--------------- linear_interpolation ---------------]
              |  scale_factor=128  |  scale_factor=256
1 threads: -------------------------------------------
      N=512   |       190.1        |        378.8     
      N=1024  |       380.2        |        758.5     
      N=2048  |       764.1        |       1536.3     
2 threads: -------------------------------------------
      N=512   |       113.6        |        221.4     
      N=1024  |       226.9        |        460.4     
      N=2048  |       451.6        |        902.7     
4 threads: -------------------------------------------
      N=512   |        75.6        |        147.9     
      N=1024  |       147.1        |        294.3     
      N=2048  |       295.2        |        603.4     

Times are in milliseconds (ms).
```


<details>
  <summary>The benchmark script</summary>

```python
import torch
from torch.profiler import profile, record_function, ProfilerActivity
import torch.utils.benchmark as benchmark
from diffsptk import LinearInterpolation
from itertools import product

def benchmark_linear_interpolation():
    # Create an instance of the LinearInterpolation class
    lin_interp = LinearInterpolation(100)

    # Generate some random input data
    x = torch.randn(16, 600).t()

    # Run the forward pass of the filter and measure the execution time
    with profile(activities=[ProfilerActivity.CPU], record_shapes=True) as prof:
        with record_function("LinearInterpolation"):
            y = lin_interp(x)

    print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=10))

    lengths = [512, 1024, 2048]
    scale_factors = [128, 256]
    results = []
    for N, S in product(lengths, scale_factors):
        label = "linear_interpolation"
        sub_label = f"N={N}"
        x = torch.randn(32, N, 49)
        interp = LinearInterpolation(S)

        for num_threads in [1, 2, 4]:
            results.append(
                benchmark.Timer(
                    stmt="y = interp(x)",
                    globals={"x": x, "interp": interp},
                    label=label,
                    num_threads=num_threads,
                    sub_label=sub_label,
                    description=f"scale_factor={S}",
                ).blocked_autorange(min_run_time=1)
            )

    compare = benchmark.Compare(results)
    compare.print()


if __name__ == "__main__":
    benchmark_linear_interpolation()

```
</details>

I only test the script on a Macbook with an M1 chip, but it should have similar results on other machines and OS.

## TODO
I haven't run the test scripts yet due to some problems with building sptk.
If anyone can help run the tests, I would appreciate it.