### PR TITLE
bug: TypeError in unsupported operand type(s) for ** or pow(): `numpy.ndarray` and `Tensor`

### DIFF
--- a/diffsptk/misc/utils.py
+++ b/diffsptk/misc/utils.py
@@ -203,7 +203,7 @@ def get_alpha(sr, mode="hts", n_freq=10, n_alpha=100):
 
         # Select an appropriate alpha in terms of L2 distance.
         distance = np.square(mel_freq - warped_omega).sum(axis=1)
-        selected_alpha = np.squeeze(alpha[np.argmin(distance)])
+        selected_alpha = float(np.squeeze(alpha[np.argmin(distance)]))
         return selected_alpha
 
     if mode == "hts":


### PR DESCRIPTION
https://github.com/sp-nitech/diffsptk/blob/053d8888baea01955116035973d76aaf52d8bcb7/diffsptk/misc/utils.py#L137

https://github.com/sp-nitech/diffsptk/blob/053d8888baea01955116035973d76aaf52d8bcb7/diffsptk/modules/freqt.py#L106

When `mode="auto"`, `get_alpha` returned a `numpy.ndarray`, which does not support operations with `Tensor`. In contrast, when `mode="hts"`, `get_alpha` returned a `float`. Since PyTorch has built-in compatibility for `float` types, this will not raise an error.

This PR ensures that `"auto"` mode consistently return a `float`, which avoids type errors.